### PR TITLE
docs(polymarket): add hotspots briefing for 2026-05-16

### DIFF
--- a/reports/polymarket-hotspots/2026-05-16.md
+++ b/reports/polymarket-hotspots/2026-05-16.md
@@ -1,0 +1,152 @@
+# Polymarket 热点简报 - 2026-05-16
+
+> 生成时间：北京时间 2026-05-16 13:35 CST  
+> 数据时间：脚本 collected_at_local = 2026-05-16T13:34:36+08:00  
+> 数据源：Polymarket Gamma public API  
+> 自动任务：Hermes daily-polymarket-hotspots cron
+
+## 摘要
+
+- 24h 成交量最高事件集中在体育/电竞、地缘政治、加密资产三类；体育类既有长期冠军盘，也有大量接近 0%/100% 的赛果/让分/大小分市场。
+- `2026 FIFA World Cup Winner` 以约 **$10.00M** 24h volume 位列事件第一，且总成交约 **$993.45M**、流动性约 **$234.11M**，是本次样本里深度最突出的长期体育主题。
+- 多个 5 月 15 日到期市场（NBA 比赛、Xi/Iran、Trump/Xi 关键词、US-Iran 5/15 截止项）价格已经接近 0%/100%，更像结果确认/结算期流量，不应简单解读为新的概率变化。
+- 单一市场成交量第一为 `Will Bitcoin hit $150k by June 30, 2026?`，24h volume 约 **$5.82M**，但流动性仅约 **$19.82K**，Yes 约 **1.4%**，属于高成交但盘面深度偏薄的加密资产尾部事件。
+- 地缘政治相关市场围绕 Iran、Xi、Trump、Strait of Hormuz、US-Iran 和 Israel-Syria；多数短期限问题给出极低 Yes 概率，背景需要结合外部新闻进一步确认。
+- Eurovision 2026、2028 Republican nomination、2026 NBA Champion 等长期主题仍有较高总成交/流动性，但本次 24h volume 也受个别低概率候选市场带动。
+- 本次脚本未提供历史价格序列或前日快照，因此无法计算精确涨跌；本文把 24h volume、流动性、结束日期和极端价格作为“热度/结算/风险信号”。
+
+## 24h 成交量最高事件
+
+| 排名 | 事件 | 24h Volume | 流动性 | 结束日期 | 观察 |
+|---:|---|---:|---:|---|---|
+| 1 | 2026 FIFA World Cup Winner | $10.00M | $234.11M | 2026-07-20 | 长期世界杯冠军盘，深度极高；样本内活跃子市场多为低概率队伍（Ivory Coast 0.4%、Ecuador 0.8%、Belgium 1.8% Yes）。 |
+| 2 | Pistons vs. Cavaliers | $9.04M | $908.85K | 2026-05-15 | NBA 单场事件，主胜/让分/大小分多为 0%/100%；更像赛果落地后的结算流量。 |
+| 3 | What will Trump say during bilateral events with Xi Jinping? | $7.65M | $323.63K | 2026-05-15 | 政治讲话关键词市场；Iran、Strait/Hormuz、Nuclear 的 Yes 均约 2%，期限已到，背景待确认。 |
+| 4 | Eurovision Winner 2026 | $6.71M | $6.96M | 2026-05-16 | 娱乐/赛事冠军盘；United Kingdom、Poland 接近 0%，Bulgaria 约 3.6% Yes，接近截止日需注意结算状态。 |
+| 5 | Spurs vs. Timberwolves | $6.60M | $14.89M | 2026-05-15 | NBA 单场/衍生盘；主市场 Spurs 100%，多项盘口接近结算。 |
+| 6 | When will Bitcoin hit $150k? | $5.82M | $49.84K | 多期限 | 主要成交集中在 2026-06-30 截止市场；Yes 约 1.4%，流动性相对成交偏低。 |
+| 7 | Xi meets with Iranian officials by May 15? | $4.45M | $97.39K | 2026-05-15 | 地缘政治短期限市场；Yes 约 0.1%、No 接近 100%，更偏截止/结算信号。 |
+| 8 | Internazionali BNL d'Italia: Jannik Sinner vs Daniil Medvedev | $3.12M | $480.89K | 2026-05-22 | 网球比赛市场；主市场 Sinner 约 91.5%，但部分子盘已接近 0%/100%，需核对比赛进度。 |
+| 9 | Counter-Strike: Natus Vincere vs Vitality (BO3) - IEM Atlanta Playoffs | $2.23M | $739.65 | 2026-05-16 | 电竞 BO3；主/地图市场多为 0%/100%，且流动性很低，谨慎解读。 |
+| 10 | US x Iran permanent peace deal by...? | $2.21M | $3.04M | 2026-12-31 | US-Iran 和平协议期限阶梯市场；5/15 Yes 约 0.1%，5/31 Yes 约 11.5%，6/30 Yes 约 31.5%。 |
+| 11 | 2026 NBA Champion | $2.16M | $2.27M | 2026-07-01 | 冠军期货；样本里 Timberwolves 接近 0%、Pistons 4.2%、Cavaliers 1.8% Yes。 |
+| 12 | LoL: HANJIN BRION vs DN SOOPers (BO3) - LCK Rounds 1-2 | $1.72M | $1.44K | 2026-05-15 | 电竞赛果盘；各子盘接近 100%/0%，且流动性较低，偏结算。 |
+
+## 重点市场
+
+### 1. Will Bitcoin hit $150k by June 30, 2026?
+
+- 所属事件：When will Bitcoin hit $150k?
+- 24h Volume：$5.82M
+- 流动性：$19.82K
+- 主要概率：Yes 1.4%，No 98.7%
+- 观察：成交额在单市场中最高，但盘口流动性明显低于成交额。价格显示市场认为 2026-06-30 前触及 $150k 的概率很低；这是加密资产长尾事件，不代表 BTC 即时价格预测。
+
+### 2. Xi meets with Iranian officials by May 15?
+
+- 所属事件：Xi meets with Iranian officials by May 15?
+- 24h Volume：$4.45M
+- 流动性：$98.10K
+- 主要概率：Yes 0.1%，No 100.0%
+- 观察：截止日为 2026-05-15，价格几乎归零/归一，说明本次交易量可能主要来自事件临近结束或等待结算。背景待确认。
+
+### 3. Will Trump say "Iran" during events with Xi Jinping?
+
+- 所属事件：What will Trump say during bilateral events with Xi Jinping?
+- 24h Volume：$3.86M
+- 流动性：$75.17K
+- 主要概率：Yes 2.2%，No 97.8%
+- 观察：政治讲话关键词市场热度高；同组的 `Strait/Hormuz`、`Nuclear` 也进入高成交榜。脚本只反映市场定价，不验证讲话文本事实。
+
+### 4. Internazionali BNL d'Italia: Jannik Sinner vs Daniil Medvedev
+
+- 所属事件：Internazionali BNL d'Italia: Jannik Sinner vs Daniil Medvedev
+- 24h Volume：$2.94M
+- 流动性：$399.40K
+- 主要概率：Jannik Sinner 91.5%，Daniil Medvedev 8.6%
+- 观察：主市场给 Sinner 明显优势；但同事件部分子市场（如 Set 1 Winner）已经 100%/0%，可能与比赛阶段或结算有关，需结合赛程核验。
+
+### 5. Will Trump say "Strait" or "Hormuz" during events with Xi Jinping?
+
+- 所属事件：What will Trump say during bilateral events with Xi Jinping?
+- 24h Volume：$1.70M
+- 流动性：$118.21K
+- 主要概率：Yes 2.0%，No 98.0%
+- 观察：与中美、伊朗、霍尔木兹海峡相关叙事相连，可能受地缘政治新闻驱动；当前价格仍接近 No。
+
+### 6. Israel x Syria security agreement by June 30?
+
+- 所属事件：Israel x Syria security agreement by...?
+- 24h Volume：$1.47M
+- 流动性：$7.04K
+- 主要概率：Yes 6.5%，No 93.5%
+- 观察：地缘政治期限市场，流动性较薄；脚本中该市场题干的 June 30 与 `endDate` 字段显示的 2026-01-31 存在不一致，需以市场规则页核验。
+
+### 7. US x Iran permanent peace deal by May 15, 2026?
+
+- 所属事件：US x Iran permanent peace deal by...?
+- 24h Volume：$1.22M
+- 流动性：$498.17K
+- 主要概率：Yes 0.1%，No 100.0%
+- 观察：短期限档位已经基本归零；更有参考价值的是后续档位（May 31 Yes 11.5%，June 30 Yes 31.5%），显示市场对更长窗口仍保留部分概率。
+
+### 8. Will Ivory Coast win the 2026 FIFA World Cup?
+
+- 所属事件：2026 FIFA World Cup Winner
+- 24h Volume：$1.16M
+- 流动性：$5.82M
+- 主要概率：Yes 0.4%，No 99.7%
+- 观察：世界杯冠军盘的尾部球队成交活跃，可能来自做市、组合交易或赔率校准；低概率不等同于无关注度。
+
+### 9. Will Trump say "Nuclear" during events with Xi Jinping?
+
+- 所属事件：What will Trump say during bilateral events with Xi Jinping?
+- 24h Volume：$1.11M
+- 流动性：$52.12K
+- 主要概率：Yes 1.9%，No 98.1%
+- 观察：同一政治讲话事件内第三个高成交关键词。与 Iran/Hormuz 主题重合，但目前仍接近 No。
+
+### 10. Will Trump and Putin meet next in Australia?
+
+- 所属事件：Where will Trump and Putin meet next?
+- 24h Volume：$1.03M
+- 流动性：$18.84K
+- 主要概率：Yes 0.1%，No 100.0%
+- 观察：外交会晤地点类市场，当前概率接近归零；高成交可能来自排除某个地点选项或结算前后调整。背景待确认。
+
+### 11. MicroStrategy sells any Bitcoin by May 31, 2026?
+
+- 所属事件：MicroStrategy sells any Bitcoin by ___ ?
+- 24h Volume：$492.23K
+- 流动性：$84.45K
+- 主要概率：Yes 55.5%，No 44.5%
+- 观察：相较榜单里大量极端价格市场，该市场接近五五开，信息含量可能更高；但需要核对规则中“sells any Bitcoin”的判定口径。
+
+### 12. Will Donald Trump win the Nobel Peace Prize in 2026?
+
+- 所属事件：Nobel Peace Prize Winner 2026
+- 24h Volume：$657.94K
+- 流动性：$650.97K
+- 主要概率：Yes 10.5%，No 89.5%
+- 观察：政治/奖项长期市场，流动性相对更均衡；可能与 US-Iran 等和平协议叙事联动，但本数据不能证明因果。
+
+## 风险与注意事项
+
+- **非事实来源**：预测市场价格是参与者交易后的结果，不等于事实确认，也不等于新闻核验。
+- **结算期噪音**：大量接近 0%/100% 且已到期或临近到期的市场，24h volume 可能来自结果确认、套利或结算过程。
+- **流动性差异**：部分市场成交额很高但当前流动性很低，单笔订单可能显著改变报价；不要只看成交额。
+- **时间字段异常**：个别市场题干日期与 `endDate` 字段不完全一致，应以 Polymarket 市场规则页为准。
+- **无历史涨跌**：本次脚本没有提供前日价格或 CLOB 历史序列，因此没有计算真实概率变化；“信号”仅来自本次快照的量价结构。
+- **类别偏差**：体育/电竞赛果市场在比赛结束前后容易冲上成交榜，会挤占宏观/政治/加密类主题的榜单位置。
+
+## 数据状态
+
+- 采集时间：2026-05-16T13:34:36+08:00
+- 数据源：Polymarket Gamma public API（只读公开 API，不进行交易）
+- `/events?limit=15&active=true&closed=false&ascending=false&order=volume24hr`：成功，HTTP 200，方法 `forced_doh_ip`，IP `172.64.153.51`，响应约 1,990,078 bytes。
+- `/markets?limit=25&active=true&closed=false&ascending=false&order=volume24hr`：成功，HTTP 200，方法 `forced_doh_ip`，IP `172.64.153.51`，响应约 189,456 bytes。
+- errors：无。
+
+## 免责声明
+
+本报告由自动化任务基于 Polymarket 公开 API 整理，仅用于信息观察，不构成投资建议、交易建议或事实断言。


### PR DESCRIPTION
## 报告信息

- 报告日期：2026-05-16
- 文件路径：`reports/polymarket-hotspots/2026-05-16.md`
- 数据来源：Polymarket Gamma public API（任务运行前脚本 `polymarket_hotspots_collect.py` 的 JSON 输出）
- 自动任务：由 Hermes 定时任务自动生成

## 摘要

- 整理 24h volume 最高的 Polymarket 事件与市场。
- 覆盖体育/电竞、地缘政治、加密资产、娱乐奖项等主题。
- 标注临近结算/接近 0% 或 100% 的市场，避免把结算流量误读为新信号。
- 包含数据状态、风险提示和非投资建议免责声明。

## 声明

本 PR 只包含每日 Polymarket 热点简报，不包含每日新闻精选或 X/Twitter 热点。报告基于公开只读 API 整理，不进行交易，也不构成投资建议。