### PR TITLE
docs(x): add X hot topics briefing for 2026-05-16

### DIFF
--- a/reports/x-hot-topics/2026-05-16.md
+++ b/reports/x-hot-topics/2026-05-16.md
@@ -1,0 +1,128 @@
+# X/Twitter 热点简报 - 2026-05-16
+
+> 生成时间：北京时间 2026-05-16 13:35:02 +0800
+> 数据时间：脚本 collected_at_local = 2026-05-16T13:34:36+08:00；公开网页核验时间为同日运行时
+> 自动任务：Hermes daily-x-hot-topics cron
+
+## 摘要
+- 本次数据来自公开趋势信号，`xurl` 未安装，因此不是账号个性化时间线；趋势以 Trends24 与 GetDayTrends 的公开榜单为主。
+- 全球榜与日本榜高度重合，前排被日语 ACG/手游/VTuber 话题占据：`#学マス引き放題ガシャ`、`SSR1`、`以上確定`、`すぺしゃーれ3D`、`#にじフェス2026_Day1` 等集中出现。
+- 美国榜明显由体育和直播娱乐推动：NBA 相关的 Julius Randle、Stephon Castle、Game 7、`#GoSpursGo`、Western Conference Finals 与摔角节目 `#SmackDown`、`#ROHSupercard` 同时上榜。
+- 英国榜呈现“足球 + 政治/社会议题”混合：`#AVLLIV`、Liverpool、Slot、Watkins 指向英超比赛讨论；Burnham、Makerfield、Unite the Kingdom、Manchester 等政治/公共议题持续发酵。
+- 巴西榜以本地电视剧/综艺人物与 K-pop 粉丝动员为主：`#Tresgraças`、Arminda、Gerluce、OBRIGADA ALANIS E GABI，以及 `#ENGENEs_Support_SevEN`、`#Boycott_BELIFT_For_Justice` 等。
+- 长时间趋势中，Drake、LOVE UPON A TIME EP8、Nakba、Boebert、Unite the Kingdom、`#ENGENEs_Support_SevEN` 等跨地区或长时段出现，说明娱乐、地缘/社会议题、粉丝组织型话题仍是主要驱动力。
+- 部分短词或活动名如 `#illimnt`、Make Aliens Great Again、Maid of Honour、All 20、Iceman 的具体触发事件在公开榜单中不充分，需标注为“含义待确认”。
+
+## 全球热点
+| 排名 | 话题 | 热度/推文数 | 可能原因 | 备注 |
+|---|---|---:|---|---|
+| 1 | #学マス引き放題ガシャ | 未提供 / Trends24 #1；GetDayTrends #1 | 日服手游/偶像企划“学园偶像大师”相关抽卡活动，带动日语用户集中讨论。 | 与 `SSR1`、`以上確定`、`#初星学園通知表` 形成同一话题簇。 |
+| 2 | SSR1 | 未提供 / Trends24 #2；GetDayTrends #2 | 很可能指“SSR 1 枚以上确定”等抽卡保底表述。 | 含义依赖上下文，按手游抽卡语境解读。 |
+| 3 | 以上確定 | 未提供 / Trends24 #3；GetDayTrends #3 | 与 `SSR1` 拼接后近似“SSR1 以上确定”，疑似抽卡活动卖点。 | 含义待确认，但与榜首话题高度相关。 |
+| 4 | すぺしゃーれ3D | 未提供 / Trends24 #4；GetDayTrends #4 | 日语 VTuber/娱乐企划 3D 披露或演出相关讨论。 | 与 `すぺ3D`、Speciale、`披露目決定` 同簇。 |
+| 5 | #にじフェス2026_Day1 | 未提供 / Trends24 #5；GetDayTrends #5 | Nijisanji/にじさんじ 线下或线上活动 Day 1 引发实时讨论。 | ACG/VTuber 粉丝参与度高。 |
+| 6 | #初星学園通知表 | 未提供 / Trends24 #6；GetDayTrends #8 | “初星学园”相关评价/成绩单类互动标签，可能与学园偶像大师周年活动联动。 | 与全球榜首同属日语手游/偶像话题。 |
+| 7 | すぺ3D | 未提供 / Trends24 #7；GetDayTrends #10 | `すぺしゃーれ3D` 的简称或衍生写法。 | 同一事件多写法分流。 |
+| 8 | #マツココリラックマ | 未提供 / Trends24 #8；Japan #9 | 日本本地商业/节目/角色联动类标签可能性较高。 | 含义待确认。 |
+| 9 | #illimnt | 未提供 / Trends24 #9 | 可能为品牌、音乐或粉丝活动标签。 | 含义待确认，且为新出现趋势。 |
+| 10 | Julius Randle | 未提供 / Trends24 #10；GetDayTrends #12 | NBA 球员表现、交易/伤病或季后赛讨论带动。 | 同时在美国榜 #1。 |
+| 11 | KNOW WAY WITH LEEKNOW | 未提供 / Trends24 #11；GetDayTrends #13 | K-pop / Stray Kids 成员 Lee Know 相关内容或节目宣发。 | 巴西榜也出现同主题。 |
+| 12 | リボーン | 未提供 / Trends24 #12；GetDayTrends #16 | 日语“重生/Reborn”相关娱乐、作品或活动讨论。 | 具体触发事件待确认。 |
+
+## 分地区热点
+
+### Worldwide
+| 排名 | 话题 | 热度/推文数 | 可能原因 | 备注 |
+|---|---|---:|---|---|
+| 1 | #学マス引き放題ガシャ | 未提供 | 学园偶像大师抽卡活动。 | 全球榜与日本榜同步登顶。 |
+| 2 | SSR1 | 未提供 | 抽卡保底/稀有度关键词。 | 与榜首同簇。 |
+| 3 | 以上確定 | 未提供 | “以上确定”类抽卡承诺或活动话术。 | 与 `SSR1` 联动理解。 |
+| 4 | すぺしゃーれ3D | 未提供 | 3D 披露/演出相关。 | VTuber/娱乐粉丝讨论。 |
+| 5 | #にじフェス2026_Day1 | 未提供 | Nijisanji Festival Day 1 活动。 | 事件型直播活动。 |
+| 6 | #初星学園通知表 | 未提供 | 学园偶像大师相关互动标签。 | 同一 ACG 话题群。 |
+| 10 | Julius Randle | 未提供 | NBA 相关讨论进入全球榜。 | 美国体育话题外溢。 |
+| 11 | KNOW WAY WITH LEEKNOW | 未提供 | K-pop 粉丝活动/节目。 | 巴西与全球同步出现。 |
+
+### United States
+| 排名 | 话题 | 热度/推文数 | 可能原因 | 备注 |
+|---|---|---:|---|---|
+| 1 | Julius Randle | 未提供 | NBA 赛场表现、季后赛或球队话题。 | 新出现趋势，全球榜也出现。 |
+| 2 | #SmackDown | 未提供 | WWE SmackDown 直播节目讨论。 | 摔角娱乐实时性强。 |
+| 3 | #PorVida | 未提供 | 圣安东尼奥 Spurs 常用口号/球迷标签。 | 与 `#GoSpursGo`、Stephon Castle 同簇。 |
+| 4 | Stephon Castle | 未提供 | NBA 新星/Spurs 相关讨论。 | 全球与巴西榜也出现。 |
+| 5 | #ROHSupercard | 未提供 | Ring of Honor 摔角赛事。 | 与 `#SmackDown` 形成摔角话题簇。 |
+| 6 | Game 7 | 未提供 | 北美体育淘汰赛“第七场”讨论。 | 可能关联 NBA/NHL，具体赛事待确认。 |
+| 7 | Finch | 未提供 | 可能指 NBA 教练 Chris Finch 或体育人物。 | 新出现趋势，含义待确认。 |
+| 8 | #GoSpursGo | 未提供 | Spurs 球迷动员。 | 新出现趋势。 |
+| 13 | Tina Peters | 未提供 | 美国政治/司法相关人物讨论。 | 长尾政治话题，具体新闻触发需后续核验。 |
+| 14 | Western Conference Finals | 未提供 | NBA 西部决赛话题预热或赛果讨论。 | 新出现趋势。 |
+
+### Japan
+| 排名 | 话题 | 热度/推文数 | 可能原因 | 备注 |
+|---|---|---:|---|---|
+| 1 | #学マス引き放題ガシャ | 未提供 | 学园偶像大师抽卡活动。 | 日本榜与全球榜同步。 |
+| 2 | SSR1 | 未提供 | 抽卡稀有度/保底信息。 | 与 `以上確定` 组合理解。 |
+| 3 | 以上確定 | 未提供 | “SSR1 以上确定”类活动话术。 | 含义待确认但高度相关。 |
+| 4 | すぺしゃーれ3D | 未提供 | Speciale/すぺしゃーれ 3D 相关活动。 | 同簇词包括 `すぺ3D`、`スペシャーレ3D`。 |
+| 5 | #にじフェス2026_Day1 | 未提供 | にじさんじ大型活动 Day 1。 | 直播/线下活动驱动。 |
+| 8 | #好きなおやつベスト3 | 未提供 | “最喜欢的三个零食”互动标签。 | 新出现趋势，偏轻娱乐互动。 |
+| 10 | リボーン | 未提供 | 作品/活动/“重生”关键词。 | 具体触发待确认。 |
+| 13 | 京都ハイジャンプ | 未提供 | 日本赛马“京都ハイジャンプ”赛事。 | 新出现趋势。 |
+| 15 | 披露目決定 | 未提供 | “披露/公开亮相决定”，疑似 3D 或活动公告。 | 与 Speciale/3D 同簇可能性高。 |
+
+### United Kingdom
+| 排名 | 话题 | 热度/推文数 | 可能原因 | 备注 |
+|---|---|---:|---|---|
+| 1 | Burnham | 未提供 | 可能指英国政治人物 Andy Burnham 或相关地方政治议题。 | 与 Manchester、Makerfield 同时出现，需后续核验。 |
+| 2 | Makerfield | 未提供 | 英国选区/地方政治相关讨论可能性高。 | 与 Burnham 同簇。 |
+| 3 | #SmackDown | 未提供 | WWE 节目讨论外溢到英国榜。 | 娱乐直播话题。 |
+| 4 | Drake | 未提供 | 音乐/名人话题持续。 | 全球长时间趋势之一。 |
+| 6 | #AVLLIV | 未提供 | Aston Villa vs Liverpool 比赛标签。 | 与 Liverpool、Slot、Watkins 关联。 |
+| 7 | Slot | 未提供 | Liverpool 主帅 Arne Slot 或足球战术/赛后讨论。 | 足球话题。 |
+| 8 | Unite the Kingdom | 未提供 | 英国政治/社会运动口号或活动。 | 英国榜长时间趋势 18 小时。 |
+| 9 | Liverpool | 未提供 | 英超赛事与球队讨论。 | 与 `#AVLLIV` 同簇。 |
+| 14 | Manchester | 未提供 | 可能与地方政治或公共事件相关。 | 含义待确认。 |
+
+### Brazil
+| 排名 | 话题 | 热度/推文数 | 可能原因 | 备注 |
+|---|---|---:|---|---|
+| 1 | #Tresgraças | 未提供 | 巴西电视剧/娱乐内容相关标签。 | 本地娱乐强势。 |
+| 2 | Arminda | 未提供 | 剧集人物或演员相关讨论。 | 与 Gerluce、Juquinha、Joelly 等同簇可能。 |
+| 3 | #ThekNOwWay | 未提供 | Lee Know / K-pop 粉丝活动标签。 | 与 `KNOW WAY WITH LEEKNOW` 关联。 |
+| 4 | #kNOw맘대로 | 未提供 | 韩语标签，K-pop 粉丝组织型传播。 | 巴西 K-pop 社群活跃。 |
+| 5 | KNOW WAY WITH LEEKNOW | 未提供 | Lee Know 相关节目/活动。 | 全球榜也出现。 |
+| 8 | Gerluce | 未提供 | 本地剧集角色/剧情讨论。 | 与 #Tresgraças 同簇可能。 |
+| 9 | OBRIGADA ALANIS E GABI | 未提供 | 对 Alanis 与 Gabi 的感谢/告别式粉丝表达。 | 具体节目/事件待确认。 |
+| 15 | Stephon Castle | 未提供 | NBA 话题进入巴西榜。 | 体育话题跨区传播。 |
+
+## 新出现趋势 / 长时间趋势
+
+### 新出现趋势
+- Worldwide：`#マツココリラックマ`、`#illimnt`、Speciale、`披露目決定`、Finch。前四项多与日本娱乐/角色/VTuber 相关，`#illimnt` 与 Finch 含义待确认。
+- United States：Julius Randle、`#PorVida`、Finch、`#GoSpursGo`、Western Conference Finals。美国新增热点集中在 NBA 与 Spurs 球迷动员。
+- Japan：`#好きなおやつベスト3`、Speciale、`京都ハイジャンプ`、`移籍後初ヒット`、`スチュワート`。说明日本榜除 ACG 外，也有零食互动、赛马与体育人物新闻。
+- United Kingdom：Wemby、Ukraine、`Wordle 1,792 X` 新进较低位，说明体育、国际议题与日常游戏互动仍有长尾热度。
+- Brazil：脚本未返回新的趋势条目；当前榜更像由本地娱乐与粉丝动员持续占位。
+
+### 长时间趋势
+- Worldwide：Drake 18 小时、Virgínia 17 小时、LOVE UPON A TIME EP8 15 小时、LOREAL BA REBECCA X CANNES26 15 小时、GEMINI BA LOREAL IN CANNES 11 小时。名人、剧集与戛纳/美妆品牌传播持续性较强。
+- United States：Boebert 18 小时、Maid of Honour 15 小时、Nakba 14 小时、`#FursuitFriday` 14 小时、Drake 14 小时。政治人物、国际纪念/冲突议题、亚文化标签与音乐名人并行。
+- Japan：新潟大賞典 18 小时、プロローグムービー 15 小时、Road to 50 15 小时、メ組のメ 15 小时、ガラクタロード 14 小时。赛马、影视/音乐或企划宣传占据长尾。
+- United Kingdom：Unite the Kingdom 18 小时、Nakba 16 小时、All 20 15 小时、Drake 14 小时、Iceman 14 小时。社会/政治动员与国际议题热度持续。
+- Brazil：`#ENGENEs_Support_SevEN` 21 小时、Virgínia 19 小时、LOVE UPON A TIME EP8 16 小时、`#Boycott_BELIFT_For_Justice` 16 小时、Drake 15 小时。K-pop 粉丝议题在巴西具有明显持续组织力。
+
+## 值得关注的信号
+- **日本 ACG/VTuber 话题对全球榜的影响继续增强。** 全球 Top 10 中多项日语词来自同一或相邻娱乐生态，说明在公开趋势榜上，集中粉丝活动足以显著改变 Worldwide 排名。
+- **体育仍是美国实时趋势核心。** NBA 球员、球队口号、Game 7、西部决赛等词同时出现，说明赛事节点对 X 讨论的驱动强于一般新闻周期。
+- **英国榜政治/足球双主线明显。** 足球比赛标签与地方政治/社会运动词并列，后续若出现线下活动或赛果变化，可能继续推高相关词。
+- **巴西榜显示粉丝组织型传播强。** K-pop 相关长时间趋势与本地电视剧话题并存，适合跟踪品牌/娱乐宣发与粉丝抗议标签的生命周期。
+- **多项短词需要谨慎解释。** `#illimnt`、Finch、Make Aliens Great Again、Maid of Honour、All 20、Iceman 等缺乏上下文，自动简报只能给出候选解释并标注“含义待确认”。
+
+## 数据来源
+- `x_trends_collect.py` public trend signals（本次注入数据，采集时间：2026-05-16T13:34:36+08:00）。
+- Trends24：Worldwide、United States、Japan、United Kingdom、Brazil 页面公开趋势榜；运行时网页状态核验返回 HTTP 200。
+- GetDayTrends：Worldwide “Now” 公开趋势榜；运行时网页状态核验返回 HTTP 200。
+- X API / xurl 状态：本次运行环境未安装 `xurl`，因此未读取账号时间线、私信、关注流或个性化推荐。
+
+## 免责声明
+本报告由自动化任务基于公开趋势信号整理；趋势含义可能受地区、机器人活动或短期事件影响，请以原始来源和后续报道为准。


### PR DESCRIPTION
## 报告日期
2026-05-16

## 文件路径
`reports/x-hot-topics/2026-05-16.md`

## 主要数据源
- `x_trends_collect.py` public trend signals（采集时间：2026-05-16T13:34:36+08:00）
- Trends24 public trend pages：Worldwide、United States、Japan、United Kingdom、Brazil
- GetDayTrends Worldwide public trends

## 摘要
- 全球与日本榜高度重合，日语 ACG/手游/VTuber 话题居前。
- 美国榜以 NBA、Spurs、摔角直播等体育娱乐话题为主。
- 英国榜呈现英超比赛与政治/社会议题并行。
- 巴西榜由本地娱乐剧集与 K-pop 粉丝动员共同驱动。
- 已标注 `#illimnt`、Finch、Make Aliens Great Again 等含义待确认趋势。

由 Hermes 定时任务自动生成。