### PR TITLE
docs(news): add daily briefing for 2026-05-25

### DIFF
--- a/reports/daily-news/2026-05-25.md
+++ b/reports/daily-news/2026-05-25.md
@@ -1,0 +1,144 @@
+# 每日早间新闻精选 - 2026-05-25
+
+> 生成时间：北京时间 2026-05-26 21:48:08 CST +0800  
+> 覆盖日期：2026-05-25  
+> 自动任务：Hermes daily-news cron
+
+## 摘要
+- 中国密集推进高层外交：5 月 25 日，习近平同塞尔维亚总统武契奇会谈，并会见巴基斯坦总理夏巴兹；外交部例行记者会继续回应地区与经贸议题。
+- 重庆永川遭遇特大暴雨，多家媒体报道已造成 9 人死亡、11 人失联；南方多地防汛救灾与转移避险压力上升。
+- 山西留神峪煤矿爆炸事故持续发酵，媒体称至少 82 人遇难，涉及“阴阳图纸”等重大违规线索；后续调查和问责需以官方通报为准。
+- 俄乌战事再度升级：俄军连续两晚袭击基辅，美国之音等报道称造成 16 人死亡，并提及“榛树”高超音速导弹使用。
+- 美伊谈判与中东局势并行升温：多家媒体称谈判取得进展但仍存在变数，相关军事行动和油价波动牵动全球市场。
+- 科技与 AI 继续成为市场主线：华为发布“韬（τ）定律”，DeepSeek API 降价/新模型消息、AI 幻觉与维权讨论受到关注。
+- 财经方面，全国综合保税区前期进出口值达 2.7 万亿元；央行高层会见法国央行行长，跨境金融合作与外贸韧性受到关注。
+
+## 今日重点
+
+### 1. 中国高层外交密集：塞尔维亚、巴基斯坦议题同日推进
+- 发生了什么：5 月 25 日，习近平同塞尔维亚总统武契奇会谈，并会见巴基斯坦总理夏巴兹；相关报道同时提到中塞关系、中巴合作等议题。
+- 为什么重要：塞尔维亚与巴基斯坦均是中国重要伙伴，相关会晤涉及“一带一路”、地区安全、经贸合作和全球治理立场，对中国外交节奏与周边/欧亚合作布局具有信号意义。
+- 来源：[央视网：习近平同塞尔维亚总统武契奇会谈](https://news.google.com/rss/articles/CBMieEFVX3lxTFBFYnI2VU52NWZEZ2U3OWRlUmkxTXVqdDB6Q2R1bGNUQVJYSExleDhBNmJORUdUQzNfVVpjVEgweXdyTHdCMFB1amtqMGxyR0FYRTlMdElMbmhzcmpvelVrZk5FVTN2cDhLYVVFWmJZajF4ZkRpSW12Vg?oc=5)、[央视网：习近平会见巴基斯坦总理夏巴兹](https://news.google.com/rss/articles/CBMieEFVX3lxTE15M0pscndqeVZrY3FIOW8zUjh3V19VV29sS3VwcTE5bW03Mnd4WXZucWMwLXZnb3dyTlppdEhnTUtDNHlyTi16V0owUFc4REdrVlZWS3BYcC1YUjl6VXZ2eC0zWTBQOVBKSFltdG9ZZkZKYkh0LXUzbg?oc=5)、[外交部例行记者会](https://news.google.com/rss/articles/CBMidkFVX3lxTE5hUnQ4eDdQU1ZiT3dhOFdpaklHX2FwMDVvSG9aeWItdF85c3dYVUFobDJFamFMQzA1UFFPTk5zbkVSb0RjR2dzSHhXaFNiZmxGVExTYm5fdkdZamlpSGxmT1ZtYlY1Y2MwZFlXYVZzSTh1VDVCNlE?oc=5)。
+
+### 2. 重庆永川特大暴雨致人员伤亡，南方防汛压力持续
+- 发生了什么：中新网、财新、界面等报道，重庆永川特大暴雨已造成 9 人死亡、11 人失联；多地发布强降雨、山洪等预警，救援和紧急避险转移正在推进。
+- 为什么重要：极端降雨叠加山洪地质灾害风险，直接关系人员安全、交通和城市运行；后续重点是搜救、转移安置、灾后排查以及预警响应是否到位。
+- 来源：[中新网：重庆永川特大暴雨已致 9 人死亡、11 人失联](https://news.google.com/rss/articles/CBMiaEFVX3lxTE1KYndmcFZON3VCX2prTDY0YXVKYVlLYnBkQUZRVm5iS2RDSE1NRUIxYk8zQmtNQnM1QXFCdGNFTGs3X0FaV3VvZkNPUUlpem1vcFVaZVAwM090ODRuSG1pYzFzZUY0cTFF?oc=5)、[财新：重庆永川特大暴雨已致 9 死 11 失联](https://news.google.com/rss/articles/CBMiYkFVX3lxTFBJc2s0NW1pVm15N1poSzl3ZFItNTl0LWd0R1dFWi1sOFhiaHluOWxpSkJ3NnNNNERpOWRLZVp1MWY5bUdyUGtINWQxeEJKTFBVRFd6eUZsWl9leDMzYThXNE1n?oc=5)。
+
+### 3. 山西留神峪煤矿爆炸事故：死亡人数与违规线索引发关注
+- 发生了什么：BBC、纽约时报中文网、端传媒等报道山西留神峪煤矿爆炸事故至少 82 人死亡，仍有人下落不明，并提到企业可能存在“阴阳图纸”等重大违规问题。
+- 为什么重要：这是重大安全生产事故，涉及矿山监管、企业主体责任、救援透明度与事故问责。死亡人数和违规细节仍需以官方后续调查为准，相关信息标注为“待确认/以权威通报为准”。
+- 来源：[BBC：中国山西矿难至少 82 死](https://news.google.com/rss/articles/CBMiZkFVX3lxTE10Uk9jalV2VmZ3SklVR1U5b1hZRVpvcHFlakxYU3BRQkxLSFpwTGhyMXBJV3FadHZwcDhCb1RUQVVjejVRd0VJZWZib0t1SUhNUFI5WkhlRU5ib2FoZk1ROTBPMVJpd9IBa0FVX3lxTE91OXJsenBPdHdNNVpob25uOFUwbTY5TTMyMDE4M3g1NnlsRFREWHFZSDMxWmZocjJrTzBTaEdIUnNZaGNVYnJMUUJ3R2F0cWRTVHJtR0pMVTkwM3F0UVhuVnJkLTczdWtkYVFn?oc=5)、[纽约时报中文网：山西煤矿爆炸事故已致 82 人死亡](https://news.google.com/rss/articles/CBMid0FVX3lxTFB1ZU5hYXFMYlZJSjNrWDI5d1dGcUZlSU5HNkd2dlhnYVFIN0FTUXJLR1pRLVp3b2lGckJzQmxPSWd4OFlHYS02WWsyQlJCNjl5UGRQaEQ5VFNicURJX1lvbjNyekhNQ2RyWFlmQy14TDJUQUlob2Mw?oc=5)、[端传媒：企业涉重大违规](https://news.google.com/rss/articles/CBMijwFBVV95cUxOcVFSZjZZSVFPNmEzcG9ybGNBbDRScUxoNHB2YzZjTk1rWWZaVzJ1azA0QnRwU3pXTXhlOGp6cEJrY3J3UG0zbmF3dTlrenRUS3hEUmUzb0xsMUhTaXdwVzR3YWpLTmlmcE45VUtYWlY0ZWFxNzN5NHNnN0MzMmN2b3pDSldnei1wOEFCWlNYbw?oc=5)。
+
+### 4. 俄乌战事升级：基辅遭连续袭击
+- 发生了什么：美国之音报道，俄罗斯连续两晚袭击基辅，造成 16 人死亡，并称“榛树”高超音速导弹被用于此次大规模袭击之一；中新、华尔街日报中文网等也关注基辅遭袭。
+- 为什么重要：对乌克兰首都的大规模袭击增加平民伤亡和基础设施压力，也可能影响欧洲安全政策、军援节奏以及俄乌谈判空间。
+- 来源：[美国之音：俄罗斯连续两晚袭击基辅](https://news.google.com/rss/articles/CBMiwwFBVV95cUxNMExwLW44bWxrenV5NF9ybmRyaUVJYWlmMWVudkNWR2R6blVGc3pvTmlWb1gza1VXVDQtakY0RkpVWXl5SWZZWEdDcXBIdWkyUHgybjBOcmFFSFg4Zk1ZZlZ3UXFFMGRiS3NBMGsxVkhpV0x6dWFwdDhjenMyT19sOV9DUmxmc3ctNkdOaldxQXB6WllsTHFTemtEQU9aZXJPRS1NVmEzdXhMVWFGdHZOenl2VDFZODk0bGdqLUtNMTRFVDjSAcMBQVVfeXFMTTBMcC1uOG1sa3p1eTRfcm5kcmlFSWFpZjFlbnZDVkdkem5VRnN6b05pVm9YM2tVV1Q0LWpGNEZKVVl5eUlmWVhHQ3FwSHVpMlB4Mm4wTnJhRUhYOGZNWWZWd1FxRTBkYktzQTBrMVZIaVdMenVhcHQ4Y3pzMk9fbDlfQ1JsZnN3LTZHTmpXcUFwelpZbExxU3prREFPWmVyT0UtTVZhM3V4TFVhRnR2Tnp5dlQxWTg5NGxnai1LTTE0RVQ4?oc=5)。
+
+### 5. 美伊谈判有进展但中东局势仍不稳
+- 发生了什么：新华网、RFI、美国之音等报道称，美伊谈判出现进展，但各方对协议是否接近达成仍有分歧；部分报道同时提到空袭、资产解冻和油价波动。
+- 为什么重要：伊朗核与地区安全议题直接影响中东局势、能源价格和全球风险偏好。当前消息存在多方表述差异，需持续跟踪官方声明。
+- 来源：[新华网：美伊协议——即将达成还是变数重重？](https://news.google.com/rss/articles/CBMif0FVX3lxTFAtN0FRS1lYNDBUNzA0Z0NPOExLRC03MXdtWWFHaHhUNnFxT2R?oc=5)、[美国之音：卢比奥称伊朗问题取得进展](https://news.google.com/rss/articles/CBMi4AFBVV95cUxOajR1U0o0UVVRMGN6YVZZVUJtVnpDbmtTVlJFb1dTUGtRR1dQdzA3dUtQVkxXWWwtb1JoX3ZWbU0zZlVSd0ZwTUJIbUFONThYZWFndTJXZlN3ZHZKcjZmVE9FTmpjMFFXOHp6NjlwcTJ3cy16VzdmOGFmREZGbFJ4TWNTRWRFckxFMWpRTzMwOFpMcEY5ZElTYmNGVlJWd3lkUnRjcTEwdERXNS0ybElpbDBCYUYyb25Ua2tpQWpUR0tHNDZNblUyRF9hMWN6aDdkWnlGR1MxRGhiN2V3RGVpR9IB4AFBVV95cUxOajR1U0o0UVVRMGN6YVZZVUJtVnpDbmtTVlJFb1dTUGtRR1dQdzA3dUtQVkxXWWwtb1JoX3ZWbU0zZlVSd0ZwTUJIbUFONThYZWFndTJXZlN3ZHZKcjZmVE9FTmpjMFFXOHp6NjlwcTJ3cy16VzdmOGFmREZGbFJ4TWNTRWRFckxFMWpRTzMwOFpMcEY5ZElTYmNGVlJWd3lkUnRjcTEwdERXNS0ybElpbDBCYUYyb25Ua2tpQWpUR0tHNDZNblUyRF9hMWN6aDdkWnlGR1MxRGhiN2V3RGVpRw?oc=5)、[RFI：美国在谈判进展之际仍对伊朗发动空袭](https://news.google.com/rss/articles/CBMi6wNBVV95cUxNLUpvQm8wOVltNDFmZWJwQXBtclMxWlBDYU5kbXVEcEJLUjJWRWZHTGZVLW5BanNRTzR5ZVBvM2oxajExU1BCdkdVc0VmdkpWZGt1ZGlpcm92bFM2Z01JajVqa1lTLVY0ZGVSR3N1MHFYQ2FtZXZPSkJvalpuTHJNdDFLTzFrbzRZMHZEbVBkc1c3VTI5Y21HbjE0b1NHWEpkQ2J0em5VOWJTa3JKa1BBUVRtSmRlM3U5SGY4cS16a2VnTDVYRmZ6OGt4RGtWNUc0WnNVOEMwZy1rUnNLNjNSNkxwYjZqQkJycUZSMFJSUm5lbHJaOGdRMGVzemwyZ1dpTHBIcHJiMDNlZ1JEQmtNMWNPWHRwUFZtRW1BdFU1eEE5dk0zXzBrNzUxTnpHU3MzR012U20teXM2emxBMFJxeDdBRndfN3Y4SmVZeWw2dGRuZ0ZvLUdKV0RlY0FRVElidlFWZmQtejBhTER1RGpZc3pHZjg1ZVFOdUZIMUlHRWFmcTFGYmVsLTc4b2FSMDhDcGFHbVR2STVlT1JQUF9rYmZpSEYtSHlDY19rcHZ1eHczR3Ztd2ZodnZLVGNBU2kxc3NHa0QwWUVicjNNbzVxbHNqRzk1c01ObGdOTGw4MXZXWFBEUThlVGtYdw?oc=5)。
+
+### 6. 科技主线：华为“韬（τ）定律”、DeepSeek 动态与 AI 幻觉治理
+- 发生了什么：华为发布“韬（τ）定律”，称通过系统级创新提升晶体管密度与系统性能；财新、前瞻网等关注 DeepSeek 新模型/API 降价等 AI 生态动态；央视网推出 AI 幻觉与维权解读。
+- 为什么重要：半导体与大模型能力、成本变化会影响算力产业链、应用落地和资本市场预期；AI 幻觉与责任边界也关系消费者权益和平台治理。
+- 来源：[华为：发表韬（τ）定律](https://news.google.com/rss/articles/CBMibEFVX3lxTE1YQkFVcGh4T2YwT3FQZGhzbTkzWEp1dmpBaVFLOFN6LW5aR3lmZUM1N09lamxyRXBlZnluUUFnc0lLRTNNTng0QkFYYUlJNk1fMVhJT1hsT2oybDF0cVRaNXd3V0hhQV9UeXhYaA?oc=5)、[财新 T 早报：DeepSeek、神舟二十三号等科技动态](https://news.google.com/rss/articles/CBMiZ0FVX3lxTE5tTWtrdW1DVTlkbnpyVWtWMXVkY0djYVZ2LU9Tb1lrUV9HOFpUSWdYRXl1dWhiWlhQRW56RHN1VlZ1c0lrY2RqTkRtY2xKVHA4aGFESGRYM1NnaFBIWnI2SjhBb2lKT0k?oc=5)、[央视网：AI 为啥会胡说八道？](https://news.google.com/rss/articles/CBMieEFVX3lxTE1WNGJVcU5qeGJrTENYNE52RFZpTmg3S0tNWVBLb252eXdMd09Hdm53OUFTMU5ZUmlIaTVXYm5aT3pveHA1alYtMXQ0TUhnUlM0ZmpaVXJ1QVl3YU4yWFhWUTJvc0FrNlJSNkRNek9ZT1lTRTZIV3V2Tg?oc=5)。
+
+### 7. 外贸与金融：综合保税区进出口、央行对外交流受关注
+- 发生了什么：人民日报报道全国综合保税区进出口值达 2.7 万亿元；中国人民银行行长潘功胜会见法国央行行长德加洛。
+- 为什么重要：综合保税区是外贸、加工制造与跨境供应链的重要载体，数据体现外贸韧性；央行对外交流则与跨境支付、金融稳定、人民币国际化及中欧金融合作相关。
+- 来源：[人民日报：全国综合保税区进出口值达 2.7 万亿元](https://news.google.com/rss/articles/CBMigwFBVV95cUxNQlhOZ0ZwcU9xSUl0Y0JteDNDWU9fOTM0ZHJXeFhCUWtTZGtLXzgxSjZKdloyMTE0ZnVESUVLTThwZ1p1c1dYdElndG1PT3ZScnNrbXFBZmYwb0w1eld3dlFsNWY0cjA1UC16TlBwTkJGZmxGaFBZNWVSVGw0dzJudTFyMA?oc=5)、[新浪财经：潘功胜会见法国央行行长德加洛](https://news.google.com/rss/articles/CBMingJBVV95cUxQZ1JfaWt3NU53R1pOcTBCVVI4SHZIa1FJN2ZGNGVBZVBNQUVEd1BGTS1pSGJNb2RoOFVBWWNBZ19HUWI4bXE3SGI0bnNwb1ZvUjhFcjRiWklZUjhKaFhwUWg0NkpOdTg2ek0xblhMejd5emNRZDRDUDVaaFFndG1YODlfaXB1cW45VklFd1FkWFZ3Y25TcGNuOHlsVDN6emVFTk5ZVEhBYlNsVEVvWHB1aHpCUjF3YTdWQ2h5MUdPVDFRZS12R000eW9BNHotcERWTDhBNWFQWXktSkEtMlJwV3FIWnFyYTF2RnB2M29Nem5rTU9XbS1QLTRVMGtjRnQ4ckJWQmJ2OFE0UGI5Sm1EQmJVNUV2Wlc4TzNsbVB3?oc=5)。
+
+### 8. 文博会与文化科技融合：数智化成为文化产业关键词
+- 发生了什么：第二十二届深圳文博会相关报道集中出现，媒体称“数智融合”激活文化产业新动能，AI、大模型与文创产品在展会中密集亮相。
+- 为什么重要：文化产业正在与 AI、数字内容、沉浸式体验等技术结合，既是消费升级方向，也反映地方文化产业和数字经济的政策着力点。
+- 来源：[搜狐网：第二十二届文博会启幕，数智融合激活文化产业新动能](https://news.google.com/rss/articles/CBMiVkFVX3lxTE1SQmdlRXV6UjhDSmd5Z3pJTnlwTlhVYVlkYlJmTUdydWxaTkt6eGRObTVDVkhYZkZnRWFmZnZoQnVLc292NWtFekdPbm0zVTZlY0F4ZndB?oc=5)、[China Daily：中国文化产业第一展实践观察](https://news.google.com/rss/articles/CBMigAFBVV95cUxOUDdUYTZaRVN6aW1CaUJ2OVRPU3l5MXVPOUxOclJhMTFVdVp6WmtRTUdXWk5Kdms2UFhfN1lKMFdTX2JLZE9uVUNmejFsYi00Sk51Y0JlUjRJSk5paHVRME5ZQ2JTeW1XUDdYVkRIeE1HVFFEb2d3UW5rTW5HLXFDVg?oc=5)。
+
+## 国内
+
+### 高层外交与政策回应
+- 发生了什么：围绕塞尔维亚、巴基斯坦、外交部记者会等议题，5 月 25 日中国官方和央媒发布多条时政消息。
+- 为什么重要：同日多场外交活动显示中国对欧亚伙伴关系、区域安全与经贸合作的持续投入。
+- 来源：央视网、外交部。
+
+### 重庆永川暴雨与南方防汛
+- 发生了什么：重庆永川特大暴雨造成严重人员伤亡；多地继续面对强降雨、山洪和城市内涝风险。
+- 为什么重要：极端天气事件对基层预警、应急响应、基础设施韧性提出更高要求。
+- 来源：中新网、财新、界面、央视网。
+
+### 山西煤矿爆炸事故调查
+- 发生了什么：山西留神峪煤矿爆炸事故死亡人数和违规线索被多家媒体持续追踪。
+- 为什么重要：矿山安全生产、事故信息透明和问责机制成为舆论焦点；具体责任认定仍待官方调查。
+- 来源：BBC、纽约时报中文网、端传媒、人民网等。
+
+## 国际
+
+### 俄乌：基辅遭连续大规模袭击
+- 发生了什么：俄罗斯对基辅的连续袭击造成伤亡，相关报道提到导弹和无人机的大规模使用。
+- 为什么重要：战事升级可能继续牵动欧洲安全、能源市场与西方对乌援助节奏。
+- 来源：美国之音、中新网、华尔街日报中文网。
+
+### 美伊：谈判进展与军事风险并存
+- 发生了什么：美伊谈判被多家媒体称有进展，但是否接近协议仍存在分歧；部分报道称地区军事行动仍在发生。
+- 为什么重要：若谈判破裂或冲突升级，将直接影响中东局势、油价和全球避险资产。
+- 来源：新华网、RFI、美国之音、21 财经。
+
+### 中美与贸易叙事继续受关注
+- 发生了什么：围绕关税、非洲市场、对华政策等议题，多家国际媒体继续报道中美博弈。
+- 为什么重要：贸易政策变化可能影响企业供应链、出口市场与地缘经济格局。
+- 来源：华尔街日报中文网、纽约时报中文网、BBC、RFI。
+
+## 科技 / AI
+
+### 华为“韬（τ）定律”引发半导体产业链关注
+- 发生了什么：华为发布“韬（τ）定律”，相关报道围绕先进封装、系统级创新、晶体管密度和性能提升展开。
+- 为什么重要：在先进制程受限背景下，系统级创新和封装路线可能成为国产半导体突破的重要路径。
+- 来源：华为、新华网、财联社、华尔街见闻。
+
+### DeepSeek 与 AI 成本竞争继续升温
+- 发生了什么：财新、前瞻网等报道 DeepSeek 新模型/API 降价等动态。
+- 为什么重要：大模型调用成本下降会推动应用扩散，也会加剧平台间价格竞争和算力供需变化。
+- 来源：财新、前瞻网。
+
+### AI 幻觉与消费者维权成为治理议题
+- 发生了什么：央视网发布关于 AI “胡说八道”及误导后维权的专家解读。
+- 为什么重要：AI 生成内容从效率工具进入消费场景后，准确性、责任边界和维权路径会成为监管和平台治理重点。
+- 来源：央视网。
+
+## 财经 / 市场
+
+### 全国综合保税区进出口值达 2.7 万亿元
+- 发生了什么：人民日报报道全国综合保税区进出口值达 2.7 万亿元。
+- 为什么重要：综合保税区连接制造、物流和跨境贸易，是观察外贸韧性与开放平台效能的重要窗口。
+- 来源：人民日报。
+
+### 央行对外金融交流
+- 发生了什么：中国人民银行行长潘功胜会见法国央行行长德加洛。
+- 为什么重要：中欧央行层面沟通有助于金融稳定、支付清算、监管合作和宏观政策沟通。
+- 来源：新浪财经等。
+
+### 美伊消息影响油价和避险资产
+- 发生了什么：多家财经媒体称美伊谈判进展、资产解冻等消息带动国际油价波动，金银等避险资产也受影响。
+- 为什么重要：能源价格与地缘风险会传导至通胀预期、货币政策和全球市场风险偏好。
+- 来源：21 财经、每日经济新闻、RFI。
+
+## 社会 / 其他
+
+### 极端天气与安全生产成为舆论焦点
+- 发生了什么：重庆暴雨、南方防汛以及山西煤矿爆炸事故在同一新闻周期内受到集中关注。
+- 为什么重要：自然灾害与生产安全事故叠加，考验地方应急管理、行业监管和信息发布机制。
+- 来源：中新网、财新、BBC、人民网。
+
+### 文博会展示文化产业数字化
+- 发生了什么：深圳文博会相关报道强调 AI、大模型、数字文创和沉浸式体验。
+- 为什么重要：文化消费与科技融合为地方产业升级提供新场景，也可能成为文旅、内容平台和硬件企业的新增长点。
+- 来源：China Daily、搜狐网、广东省粤港澳合作促进会。
+
+## 参考来源
+- Google News RSS 聚合（中文新闻与国际媒体检索，覆盖日期 2026-05-25）。
+- 央视网、外交部、人民日报、新华社/新华网、中新网、财新、界面新闻、澎湃新闻、21 财经、新浪财经、财联社、华为官网。
+- BBC、美国之音、RFI、纽约时报中文网、华尔街日报中文网、端传媒、China Daily。
+
+## 免责声明
+本报告由自动化任务基于公开信息整理，不构成投资、法律或其他专业建议；重大事项请以权威来源为准。


### PR DESCRIPTION
## 报告日期
2026-05-25

## 文件路径
`reports/daily-news/2026-05-25.md`

## 主要来源
- 中文来源：央视网、外交部、人民日报、新华社/新华网、中新网、财新、界面新闻、澎湃新闻、21 财经、新浪财经、财联社、华为官网等。
- 国际/聚合来源：Google News RSS、BBC、美国之音、RFI、纽约时报中文网、华尔街日报中文网、端传媒、China Daily 等。

## 摘要
- 中国高层外交密集推进，涉及塞尔维亚、巴基斯坦及外交部例行记者会议题。
- 重庆永川特大暴雨与南方防汛、山西留神峪煤矿爆炸事故成为国内安全与应急焦点。
- 俄乌战事升级、美伊谈判与中东军事风险牵动国际局势和能源市场。
- 华为“韬（τ）定律”、DeepSeek 动态与 AI 幻觉治理继续推动科技/AI 议题。
- 外贸与金融方面关注综合保税区进出口、央行对外交流和国际油价波动。

## 自动生成声明
由 Hermes 定时任务自动生成。该 PR 仅包含“每日早间新闻精选”，不包含 X 热点或 Polymarket 热点。
