### PR TITLE
docs(polymarket): add hotspots briefing for 2026-05-26

### DIFF
--- a/reports/polymarket-hotspots/2026-05-26.md
+++ b/reports/polymarket-hotspots/2026-05-26.md
@@ -1,0 +1,125 @@
+# Polymarket 热点简报 - 2026-05-26
+
+> 生成时间：北京时间 2026-05-26 23:50
+> 数据时间：脚本 `collected_at_local=2026-05-26T23:45:08+08:00`
+> 数据源：Polymarket Gamma public API
+> 自动任务：Hermes daily-polymarket-hotspots cron
+
+## 摘要
+- 今日 24h 成交量最高的主题是 **2026 FIFA World Cup Winner**，事件级 24h Volume 约 **$20.34M**，且流动性约 **$277.09M**，但高成交主要集中在低概率球队子市场，需谨慎解读为盘口轮动而非胜率大幅上升。
+- **伊朗相关地缘政治**占据多个高成交席位：停火延续、US x Iran permanent peace deal、伊朗关闭空域、霍尔木兹海峡交通等市场共同形成今日主线。
+- **近到期或已到期市场**非常多，多个价格接近 0%/100%；这类市场可能受结算状态、结果确认或流动性枯竭影响，不能简单视为新的预测信号。
+- **Bitcoin $150k by Jun 30, 2026** 是单一市场 24h Volume 第一（约 **$5.82M**），但流动性仅约 **$19.8K**，Yes 概率约 **1.4%**，显示成交集中但盘口深度偏薄。
+- 体育热点包括 **Spurs vs. Thunder**、LoL DK vs HLE、Roland Garros、IPL 等；其中已结束或即将结束赛事更容易出现 0%/100% 的结算型价格。
+- 宏观方面，**June Fed Decision** 市场继续显示对 50+ bps 加息或降息的低概率预期；24h Volume 约 **$2.42M**，事件级流动性约 **$3.02M**。
+- 政治长线市场（2028 民主党/共和党总统提名）仍有高流动性与成交，但时间跨度很长，短期成交不代表基本面已确认。
+- 本次脚本未提供逐笔成交、订单簿深度或价格历史序列；“概率变化信号”主要依据 24h 成交量集中、概率接近边界、流动性差异和事件类别判断。
+
+## 24h 成交量最高事件
+| 排名 | 事件 | 24h Volume | 总 Volume | 流动性 | 结束日期 | 观察 |
+|---|---|---:|---:|---:|---|---|
+| 1 | 2026 FIFA World Cup Winner | $20.34M | $1.22B | $277.09M | 2026-07-20 | 长线体育冠军盘成交异常活跃；子市场多为低概率球队，可能是盘口轮动。 |
+| 2 | Iran ceasefire continues through...? | $12.96M | $37.63M | $438.38K | 未列明 | 伊朗停火持续性是今日地缘主线之一；部分子市场接近结算状态。 |
+| 3 | US x Iran permanent peace deal by...? | $9.88M | $187.94M | $1.69M | 2026-12-31 | 近端日期差异明显：May 26 已低至 2.9%，May 31 约 25.5%，Jun 7 约 36.5%。 |
+| 4 | When will Bitcoin hit $150k? | $5.82M | $18.36M | $49.84K | 2027-01-01 | 成交集中但流动性偏低；6 月底达 $150k 的 Yes 仅约 1.4%。 |
+| 5 | Iran closes its airspace by...? | $4.12M | $41.76M | $626.58K | 2026-05-31 | May 31 关闭空域 Yes 约 17.2%，May 27 约 7.2%；背景待确认。 |
+| 6 | LoL: Dplus KIA vs Hanwha Life Esports | $3.98M | $3.99M | $1.49K | 2026-05-26 | 电竞赛事接近或进入结算，多个盘口已显示 0%/100%。 |
+| 7 | F1 Drivers' Champion | $2.88M | $159.13M | $12.80M | 2026-12-06 | 高成交集中在低概率车手子市场，长线流动性充足但不代表冠军格局已定。 |
+| 8 | Elon Musk # tweets May 19 - May 26, 2026? | $2.79M | $9.60M | $962.71K | 2026-05-26 | 计数类市场接近到期；240-259 推文区间接近五五开，其余多接近 0%。 |
+| 9 | Bitcoin above ___ on May 26? | $2.79M | $3.61M | $475.51K | 2026-05-26 | 日内价格阈值盘多数接近结果确认；$76k 以上约 94.4%，$80k 以上约 0.1%。 |
+| 10 | Democratic Presidential Nominee 2028 | $2.62M | $1.16B | $58.61M | 2028-11-07 | 长线政治提名盘流动性高；高成交子市场未必代表高胜率。 |
+| 11 | Fed Decision in June? | $2.42M | $43.49M | $3.02M | 2026-06-17 | 50+ bps 加息或降息均被定价为低概率，市场更偏向无极端调整。 |
+| 12 | Spurs vs. Thunder | $2.22M | $2.71M | $4.35M | 2026-05-27 | NBA 单场盘口较活跃，Thunder 胜率约 60.5%，大小分接近平衡。 |
+| 13 | US announces new Iran agreement/ceasefire extension by...? | $2.13M | $7.38M | $275.11K | 未列明 | 与伊朗停火/协议消息面相关；May 31 公告或延长 Yes 约 31.5%。 |
+| 14 | Republican Presidential Nominee 2028 | $1.83M | $641.19M | $42.09M | 2028-11-07 | 长线政治盘继续有成交；J.D. Vance 子市场约 33.6% Yes。 |
+| 15 | What will WTI Crude Oil (WTI) hit in May 2026? | $1.71M | $30.48M | $4.63M | 2026-05-31 | 大宗商品波动与中东风险可能相关；WTI 触及 $110 高点 Yes 约 5.5%。 |
+
+## 重点市场
+### 1. Will Bitcoin hit $150k by June 30, 2026?
+- 所属事件：When will Bitcoin hit $150k?
+- 24h Volume：$5.82M
+- 流动性：$19.82K
+- 主要概率：Yes 1.4%，No 98.7%
+- 观察：单市场成交排名第一，但盘口流动性明显低于成交额；更像高换手/集中交易，而不是市场认为短期大涨已成主线。
+
+### 2. Will the Iran ceasefire continue through May 24?
+- 所属事件：Iran ceasefire continues through...?
+- 24h Volume：$5.80M
+- 流动性：$426.17K
+- 主要概率：Yes 97.5%，No 2.5%
+- 观察：日期早于本次采集日，可能涉及结算确认、市场状态更新或历史结果交易；不应当作为前瞻概率直接解读。
+
+### 3. US x Iran permanent peace deal by May 26, 2026?
+- 所属事件：US x Iran permanent peace deal by...?
+- 24h Volume：$5.24M
+- 流动性：$311.57K
+- 主要概率：Yes 2.9%，No 97.2%
+- 观察：近到期合约，市场基本否定当日达成永久和平协议；背景待确认。
+
+### 4. Iran closes its airspace by May 24?
+- 所属事件：Iran closes its airspace by...?
+- 24h Volume：$3.29M
+- 流动性：$388.36K
+- 主要概率：Yes 0.8%，No 99.2%
+- 观察：同样是已过日期盘口，价格接近 No；更可能反映结算预期而非新的未来事件判断。
+
+### 5. US x Iran permanent peace deal by May 31, 2026?
+- 所属事件：US x Iran permanent peace deal by...?
+- 24h Volume：$2.96M
+- 流动性：$549.59K
+- 主要概率：Yes 25.5%，No 74.5%
+- 观察：相比 May 26 子市场，May 31 给出更高 Yes 概率，是伊朗相关主题里更有前瞻意义的观察点。
+
+### 6. Spurs vs. Thunder
+- 所属事件：Spurs vs. Thunder
+- 24h Volume：$1.69M
+- 流动性：$2.54M
+- 主要概率：Spurs 39.5%，Thunder 60.5%
+- 观察：主胜负盘口相对平衡且流动性好；同事件的让分 Thunder -5.5 与大小分 216.5 更接近五五开。
+
+### 7. Will the Iranian regime fall by May 31?
+- 所属事件：Will the Iranian regime fall by May 31?
+- 24h Volume：$1.68M
+- 流动性：$1.48M
+- 主要概率：Yes 0.2%，No 99.8%
+- 观察：该市场有显著关注度，但价格极低，说明成交不等同于高概率；背景待确认。
+
+### 8. Strait of Hormuz traffic returns to normal by end of May?
+- 所属事件：Strait of Hormuz traffic returns to normal by end of May?
+- 24h Volume：$1.33M
+- 流动性：$433.34K
+- 主要概率：Yes 2.5%，No 97.5%
+- 观察：与中东地缘、航运和能源风险相关；目前市场显著偏向月底前不会恢复正常。
+
+### 9. Will the Fed increase interest rates by 50+ bps after the June 2026 meeting?
+- 所属事件：Fed Decision in June?
+- 24h Volume：$1.18M
+- 流动性：$1.58M
+- 主要概率：Yes 0.2%，No 99.8%
+- 观察：市场几乎排除 50+ bps 加息情景；同事件中 50+ bps 降息 Yes 约 0.8%，25 bps 降息 Yes 约 1.7%。
+
+### 10. Will Ivory Coast win the 2026 FIFA World Cup?
+- 所属事件：2026 FIFA World Cup Winner
+- 24h Volume：$1.36M
+- 流动性：$4.99M
+- 主要概率：Yes 0.2%，No 99.8%
+- 观察：世界杯冠军盘成交最高的子市场之一，但隐含概率极低；可能是低价长尾队伍交易活跃。
+
+## 风险与注意事项
+- 预测市场价格不是事实来源，只是特定市场参与者在特定盘口和规则下形成的价格。
+- 24h Volume 高不等于概率高；高成交可能来自套利、对冲、盘口轮动、结算前交易或低流动性下的集中成交。
+- 流动性和盘口深度差异很大：例如 Bitcoin $150k 近端市场成交很高但流动性偏低，价格更容易受单侧交易影响。
+- 多个市场结束日期早于或接近本次采集时间，价格接近 0%/100% 时需先判断是否已经进入结果确认或结算流程。
+- 本次数据来自 Gamma 发现接口，未包含订单簿、成交明细、持仓变化或历史价格序列；因此无法严谨计算“24h 概率变化”。
+- 地缘政治、宏观和体育赛事背景可能快速变化；报告中的背景解释仅作市场观察，未做新闻事实核验。
+
+## 数据状态
+- 采集时间：`2026-05-26T23:45:08+08:00`。
+- 数据源：`Polymarket Gamma public API`。
+- `/events?limit=15&active=true&closed=false&ascending=false&order=volume24hr`：请求成功，HTTP 200，返回约 2,171,694 bytes。
+- `/markets?limit=25&active=true&closed=false&ascending=false&order=volume24hr`：请求成功，HTTP 200，返回约 181,889 bytes。
+- 网络状态：本次脚本使用 DoH 解析后的强制 IP 访问方式；两个接口均成功返回。
+- errors：无。
+
+## 免责声明
+本报告由自动化任务基于 Polymarket 公开 API 整理，仅用于信息观察，不构成投资建议、交易建议或事实断言。


### PR DESCRIPTION
## Report
- 日期：2026-05-26（北京时间）
- 文件：`reports/polymarket-hotspots/2026-05-26.md`
- 数据来源：Polymarket Gamma public API（预运行脚本 `polymarket_hotspots_collect.py` 输出）
- 自动任务：由 Hermes 定时任务自动生成

## Summary
- Adds the daily Chinese Polymarket hotspots briefing for 2026-05-26.
- Highlights 24h volume leaders across events and markets.
- Covers key themes: 2026 World Cup outrights, Iran-related geopolitics, Bitcoin threshold markets, Fed decision, sports, long-horizon US politics, and WTI crude.
- Includes data status, collection caveats, risk notes, and non-investment-advice disclaimer.

## Validation
- Verified report file is non-empty.
- Verified title/date/data source/disclaimer are present.
- Verified no credential-like strings are present in the report content.

由 Hermes daily-polymarket-hotspots cron 自动生成。
